### PR TITLE
feat(portfolio): Add favorite stocks management

### DIFF
--- a/src/main/java/com/example/burza/controller/PortfolioController.java
+++ b/src/main/java/com/example/burza/controller/PortfolioController.java
@@ -1,18 +1,47 @@
 package com.example.burza.controller;
 
+import com.example.burza.model.Portfolio;
 import com.example.burza.service.PortfolioService;
 import org.springframework.web.bind.annotation.*;
-
-import com.example.burza.model.Recommendation;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/portfolio")
 public class PortfolioController {
-
     private final PortfolioService portfolioService;
 
     public PortfolioController(PortfolioService portfolioService) {
         this.portfolioService = portfolioService;
     }
 
+    /**
+     * Retrieves list of favorite stocks.
+     * @return List of favorite stock symbols
+     */
+    @GetMapping("/favorites")
+    public List<String> getFavoriteStocks() {
+        return portfolioService.getPortfolio().getFavoriteStocks().getSymbols();
+    }
+
+    /**
+     * Adds a stock to favorites.
+     * @param symbol Stock symbol to add
+     * @return true if added successfully, false if limit reached
+     */
+    @PostMapping("/favorites/{symbol}")
+    public boolean addFavoriteStock(@PathVariable String symbol) {
+        return portfolioService.getPortfolio().getFavoriteStocks().addSymbol(symbol);
+    }
+
+    /**
+     * Removes a stock from favorites.
+     * @param symbol Stock symbol to remove
+     * @return true if removed successfully
+     */
+    @DeleteMapping("/favorites/{symbol}")
+    public boolean removeFavoriteStock(@PathVariable String symbol) {
+        return portfolioService.getPortfolio().getFavoriteStocks().removeSymbol(symbol);
+    }
+
 }
+

--- a/src/main/java/com/example/burza/model/FavoriteStocks.java
+++ b/src/main/java/com/example/burza/model/FavoriteStocks.java
@@ -1,0 +1,45 @@
+package com.example.burza.model;
+
+import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents user's favorite stocks.
+ * Maintains a list of favorite stock symbols with a maximum limit.
+ */
+@Data
+public class FavoriteStocks {
+    private static final int MAX_FAVORITES = 5;
+    private List<String> symbols;
+
+    public FavoriteStocks() {
+        this.symbols = new ArrayList<>();
+    }
+
+    /**
+     * Adds a symbol to favorites if limit not reached.
+     * @param symbol Stock symbol to add
+     * @return true if added successfully, false if limit reached
+     */
+    public boolean addSymbol(String symbol) {
+        if (symbols.size() >= MAX_FAVORITES) {
+            return false;
+        }
+        if (!symbols.contains(symbol)) {
+            symbols.add(symbol);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Removes a symbol from favorites.
+     * @param symbol Stock symbol to remove
+     * @return true if removed, false if not found
+     */
+    public boolean removeSymbol(String symbol) {
+        return symbols.remove(symbol);
+    }
+}
+

--- a/src/main/java/com/example/burza/model/Portfolio.java
+++ b/src/main/java/com/example/burza/model/Portfolio.java
@@ -18,12 +18,11 @@ import java.util.Map;
 public class Portfolio {
     private Map<String, Integer> holdings;
     private double balance;
+    private FavoriteStocks favoriteStocks;
 
-    /**
-     * Default constructor initializing an empty portfolio with a starting balance.
-     */
     public Portfolio() {
         this.holdings = new HashMap<>();
         this.balance = 10000.0;
+        this.favoriteStocks = new FavoriteStocks();
     }
 }


### PR DESCRIPTION
- Add FavoriteStocks model with 5 stocks limit
- Extend Portfolio model with favorite stocks
- Add REST endpoints for managing favorite stocks:
  - GET /favorites - retrieve favorite stocks
  - POST /favorites/{symbol} - add stock to favorites
  - DELETE /favorites/{symbol} - remove stock from favorites
- Implement limit checking and duplicate prevention
- Add basic error handling

This commit implements user ability to maintain a list of up to 5 favorite stocks in their portfolio for easier tracking and monitoring.